### PR TITLE
fix(qwen2.5-vl): correct `do_sample` logic when temperature=0.0

### DIFF
--- a/models/Qwen2_5_VL/Qwen2_5_VL_hf.py
+++ b/models/Qwen2_5_VL/Qwen2_5_VL_hf.py
@@ -51,7 +51,7 @@ class Qwen2_5_VL:
 
     def generate_output(self,messages):
         inputs = self.process_messages(messages)
-        do_sample = False if self.temperature else True
+        do_sample = self.temperature is not None and self.temperature > 0
         generated_ids = self.llm.generate(**inputs,temperature=self.temperature,top_p=self.top_p,repetition_penalty=self.repetition_penalty,max_new_tokens=self.max_new_tokens,do_sample = do_sample)
         generated_ids_trimmed = [
             out_ids[len(in_ids) :] for in_ids, out_ids in zip(inputs.input_ids, generated_ids)


### PR DESCRIPTION
Previously, `do_sample = False if self.temperature else True` led to
unexpected behavior when temperature=0, where sampling was enabled.

Now changed to:
```python
    do_sample = self.temperature is not None and self.temperature > 0
```
This ensures deterministic decoding when temperature is 0.